### PR TITLE
Fix atom tags

### DIFF
--- a/lib/atom.js
+++ b/lib/atom.js
@@ -117,7 +117,7 @@ export function atom(channel, data) {
       if (datum.tags) {
         let offset = -1
         while (++offset < datum.tags.length) {
-          items.push(x('category', {term: String(datum.tags[offset])}))
+          children.push(x('category', {term: String(datum.tags[offset])}))
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "remark-cli": "^11.0.0",
     "remark-preset-wooorm": "^9.0.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
+    "typescript": "^5.0.4",
     "xast-util-to-xml": "^3.0.0",
     "xo": "^0.53.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "remark-cli": "^11.0.0",
     "remark-preset-wooorm": "^9.0.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.0.0",
     "xast-util-to-xml": "^3.0.0",
     "xo": "^0.53.0"
   },

--- a/test.js
+++ b/test.js
@@ -1998,6 +1998,18 @@ test('atom', () => {
           name: 'title',
           attributes: {},
           children: [{type: 'text', value: 'c'}]
+        },
+        {
+          type: 'element',
+          name: 'category',
+          attributes: {term: 'x'},
+          children: []
+        },
+        {
+          type: 'element',
+          name: 'category',
+          attributes: {term: 'y'},
+          children: []
         }
       ]
     },


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

In `atom.js`, the `category`s of Entries were pushed to the Channel. The logic in `rss.js` is correct.

This PR fixed that and the corresponding test.

This PR updates the TypeScript version to 5.0 because my PNPM installed version 4.0.* due to the `^4.0.0` specifier in `package.json`, which did not support the `exactOptionalPropertyTypes` option in `compilerOptions`.

<!--do not edit: pr-->
